### PR TITLE
feat: add lesson deletion functionality with confirmation

### DIFF
--- a/src/app/admin/lessons/[courseId]/[id]/edit/page.tsx
+++ b/src/app/admin/lessons/[courseId]/[id]/edit/page.tsx
@@ -63,6 +63,33 @@ export default function EditLessonPage() {
     router.push(`/admin/courses/${courseId}/edit`);
   };
 
+  const handleDeleteLesson = async () => {
+    setIsSubmitting(true);
+    try {
+      const response = await fetch(`/api/lessons/${moduleId}`, {
+        method: 'DELETE',
+      });
+
+      if (!response.ok) {
+        let message = 'Failed to delete lesson';
+        try {
+          const errorData = await response.json();
+          message = errorData?.error || message;
+        } catch {}
+        throw new Error(message);
+      }
+
+      // Redirect back to course edit page
+      router.push(`/admin/courses/${courseId}/edit`);
+    } catch (error) {
+      console.error('Error deleting lesson:', error);
+      const msg = error instanceof Error ? error.message : 'Unknown error';
+      alert(`Failed to delete lesson: ${msg}`);
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
   const handleSave = async () => {
     if (!lessonName.trim()) {
       setErrors(prev => ({ ...prev, lessonName: "Please enter lesson name" }));
@@ -190,6 +217,8 @@ export default function EditLessonPage() {
             onSubLessonsChange={(items) => setSubLessons(items as SubLessonState[])}
             errors={errors}
             moduleId={moduleId}
+            onDeleteLesson={handleDeleteLesson}
+            isDeleting={isSubmitting}
           />
         </div>
       </SidebarInset>

--- a/src/app/admin/lessons/[courseId]/page.tsx
+++ b/src/app/admin/lessons/[courseId]/page.tsx
@@ -22,6 +22,7 @@ export default function AddLessonPage() {
   const [subLessons, setSubLessons] = useState<{ id: number; name: string; file: File | null; previewUrl?: string | null; }[]>([
     { id: 1, name: "", file: null, previewUrl: null },
   ]);
+  const [lessonId, setLessonId] = useState<string | null>(null);
 
   useEffect(() => {
     const fetchCourse = async () => {
@@ -40,6 +41,38 @@ export default function AddLessonPage() {
 
   const handleCancel = () => {
     router.push(`/admin/courses/${courseId}/edit`);
+  };
+
+  const handleDeleteLesson = async () => {
+    if (!lessonId) {
+      alert('No lesson to delete');
+      return;
+    }
+
+    setIsSubmitting(true);
+    try {
+      const response = await fetch(`/api/lessons/${lessonId}`, {
+        method: 'DELETE',
+      });
+
+      if (!response.ok) {
+        let message = 'Failed to delete lesson';
+        try {
+          const errorData = await response.json();
+          message = errorData?.error || message;
+        } catch {}
+        throw new Error(message);
+      }
+
+      // Redirect back to course edit page
+      router.push(`/admin/courses/${courseId}/edit`);
+    } catch (error) {
+      console.error('Error deleting lesson:', error);
+      const msg = error instanceof Error ? error.message : 'Unknown error';
+      alert(`Failed to delete lesson: ${msg}`);
+    } finally {
+      setIsSubmitting(false);
+    }
   };
 
   const handleCreate = async () => {
@@ -155,6 +188,8 @@ export default function AddLessonPage() {
             subLessons={subLessons}
             onSubLessonsChange={setSubLessons}
             errors={errors}
+            onDeleteLesson={lessonId ? handleDeleteLesson : undefined}
+            isDeleting={isSubmitting}
           />
         </div>
       </SidebarInset>

--- a/src/components/course/SubLessonForm.tsx
+++ b/src/components/course/SubLessonForm.tsx
@@ -5,6 +5,17 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { GripVertical, Plus, X, AlertCircle } from "lucide-react";
 import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog";
+import {
   DndContext,
   closestCenter,
   KeyboardSensor,
@@ -38,6 +49,8 @@ interface SubLessonFormProps {
   onSubLessonsChange: (items: SubLesson[]) => void;
   errors?: Record<string, string>;
   moduleId?: string;
+  onDeleteLesson?: () => void;
+  isDeleting?: boolean;
 }
 
 interface SortableSubLessonProps {
@@ -147,6 +160,8 @@ export function SubLessonForm({
   onSubLessonsChange,
   errors = {},
   moduleId,
+  onDeleteLesson,
+  isDeleting = false,
 }: SubLessonFormProps) {
   const fileInputsRef = useRef<Record<number, HTMLInputElement | null>>({});
 
@@ -291,6 +306,51 @@ export function SubLessonForm({
           + Add Sub-lesson
         </Button>
       </div>
+
+      {/* Delete Lesson Button */}
+      {onDeleteLesson && (
+        <div className="flex justify-end mt-6">
+          <AlertDialog>
+            <AlertDialogTrigger asChild>
+              <button
+                type="button"
+                className="p-0 m-0 bg-transparent border-0 text-[#2F5FAC] font-inter font-bold text-base leading-[150%] tracking-normal cursor-pointer"
+              >
+                Delete Lesson
+              </button>
+            </AlertDialogTrigger>
+            <AlertDialogContent className="w-[528px] h-[212px] p-0 !rounded-xl">
+              <AlertDialogHeader>
+                <AlertDialogTitle className="text-b1 font-medium h-14 border-b border-gray-300 py-2 px-6 flex justify-between items-center">
+                  Confirmation
+                  <AlertDialogCancel
+                    asChild
+                    className="!border-none !bg-none !shadow-none"
+                  >
+                    <button className="text-gray-500">×</button>
+                  </AlertDialogCancel>
+                </AlertDialogTitle>
+                <AlertDialogDescription className="text-b2 text-gray-700 pt-4 px-6">
+                  Are you sure you want to delete this lesson?
+                </AlertDialogDescription>
+              </AlertDialogHeader>
+              <AlertDialogFooter className="pb-2 pt-2 px-6 flex gap-3 !justify-center">
+                <AlertDialogAction
+                  asChild
+                  className="h-15 w-2/3 border border-orange-500 !text-orange-500 bg-transparent hover:bg-orange-100 px-4 py-2 rounded-lg text-b2 font-medium"
+                >
+                  <button onClick={onDeleteLesson} disabled={isDeleting}>
+                    {isDeleting ? "Deleting..." : "Yes, I want to delete this lesson"}
+                  </button>
+                </AlertDialogAction>
+                <AlertDialogCancel className="h-15 w-1/3 bg-[#2F5FAC] hover:bg-[#2F5FAC] !text-white px-4 py-2 rounded-lg text-b2 font-medium">
+                  No, keep it
+                </AlertDialogCancel>
+              </AlertDialogFooter>
+            </AlertDialogContent>
+          </AlertDialog>
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
- Delete Button: Located at bottom-right corner, blue color, Inter font
- Confirmation Popup: Size 528×212px, same as Delete Course
- Confirm Button: "Yes, I want to delete this lesson" (orange)
- Cancel Button: "No, keep it" (blue)
- Loading State: Shows "Deleting..." while deleting